### PR TITLE
Amend snippets' syntax

### DIFF
--- a/snippets/raml.json
+++ b/snippets/raml.json
@@ -79,6 +79,7 @@
 		],
 		"description": "Insert a POST method"
 	},
+
 	"Insert head": {
 		"prefix": "head",
 		"body": [
@@ -90,6 +91,7 @@
 		],
 		"description": "Insert a HEAD method"
 	},
+
 	"Insert put": {
 		"prefix": "put",
 		"body": [
@@ -101,6 +103,7 @@
 		],
 		"description": "Insert a PUT method"
 	},
+
 	"Insert option": {
 		"prefix": "options",
 		"body": [

--- a/snippets/raml.json
+++ b/snippets/raml.json
@@ -102,14 +102,14 @@
 		"description": "Insert put"
 	},
 	"Insert option": {
-		"prefix": "option",
+		"prefix": "options",
 		"body": [
-			"option:",
+			"options:",
 			"\tdescription: |",
 			"\theaders: ",
 			"\tbody: ",
 			"\tresponses: "
 		],
-		"description": "Insert option"
+		"description": "Insert options"
 	}
 }

--- a/snippets/raml.json
+++ b/snippets/raml.json
@@ -65,7 +65,7 @@
 			"\tbody: ",
 			"\tresponses: "
 		],
-		"description": "Insert get"
+		"description": "Insert a GET method"
 	},
 
 	"Insert post": {
@@ -77,7 +77,7 @@
 			"\tbody: ",
 			"\tresponses: "
 		],
-		"description": "Insert post"
+		"description": "Insert a POST method"
 	},
 	"Insert head": {
 		"prefix": "head",
@@ -88,7 +88,7 @@
 			"\tbody: ",
 			"\tresponses: "
 		],
-		"description": "Insert get"
+		"description": "Insert a HEAD method"
 	},
 	"Insert put": {
 		"prefix": "put",
@@ -99,7 +99,7 @@
 			"\tbody: ",
 			"\tresponses: "
 		],
-		"description": "Insert put"
+		"description": "Insert a PUT method"
 	},
 	"Insert option": {
 		"prefix": "options",
@@ -110,6 +110,6 @@
 			"\tbody: ",
 			"\tresponses: "
 		],
-		"description": "Insert options"
+		"description": "Insert an OPTIONS method"
 	}
 }

--- a/snippets/raml.json
+++ b/snippets/raml.json
@@ -111,5 +111,29 @@
 			"\tresponses: "
 		],
 		"description": "Insert an OPTIONS method"
+	},
+
+	"Insert patch": {
+		"prefix": "patch",
+		"body": [
+			"patch:",
+			"\tdescription: |",
+			"\theaders: ",
+			"\tbody: ",
+			"\tresponses: "
+		],
+		"description": "Insert a PATCH method"
+	},
+
+	"Insert delete": {
+		"prefix": "delete",
+		"body": [
+			"delete:",
+			"\tdescription: |",
+			"\theaders: ",
+			"\tbody: ",
+			"\tresponses: "
+		],
+		"description": "Insert a DELETE method"
 	}
 }

--- a/snippets/raml.json
+++ b/snippets/raml.json
@@ -59,7 +59,7 @@
 	"Insert get": {
 		"prefix": "get",
 		"body": [
-			"get",
+			"get:",
 			"\tdescription: |",
 			"\theaders: ",
 			"\tbody: ",
@@ -71,7 +71,7 @@
 	"Insert post": {
 		"prefix": "post",
 		"body": [
-			"post",
+			"post:",
 			"\tdescription: |",
 			"\theaders: ",
 			"\tbody: ",
@@ -82,7 +82,7 @@
 	"Insert head": {
 		"prefix": "head",
 		"body": [
-			"head",
+			"head:",
 			"\tdescription: |",
 			"\theaders: ",
 			"\tbody: ",
@@ -93,7 +93,7 @@
 	"Insert put": {
 		"prefix": "put",
 		"body": [
-			"put",
+			"put:",
 			"\tdescription: |",
 			"\theaders: ",
 			"\tbody: ",
@@ -104,7 +104,7 @@
 	"Insert option": {
 		"prefix": "option",
 		"body": [
-			"option",
+			"option:",
 			"\tdescription: |",
 			"\theaders: ",
 			"\tbody: ",

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -11,7 +11,7 @@ var assert = require('assert');
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
 var vscode = require('vscode');
-var myExtension = require('../extension');
+var myExtension = require('../');
 
 // Defines a Mocha test suite to group tests of similar kind together
 suite("Extension Tests", function() {


### PR DESCRIPTION
Noticed the snippets for the methods don't adhere to the RAML 1.0 spec.

This is how they look like as of now:
![blzjns vscode-raml-current](https://user-images.githubusercontent.com/789555/37751553-1a4d9464-2dce-11e8-869c-913d03c2c2ba.png)

After this proposal is applied:
![blzjns vscode-raml-proposal](https://user-images.githubusercontent.com/789555/37751590-38ea9598-2dce-11e8-99c1-615a9666f81e.png)